### PR TITLE
Support custom atlantis.yaml config filename on server side

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -37,6 +37,7 @@ const (
 	AllowForkPRsFlag           = "allow-fork-prs"
 	AllowRepoConfigFlag        = "allow-repo-config"
 	AtlantisURLFlag            = "atlantis-url"
+	AtlantisYAMLFilenameFlag   = "atlantis.yaml"
 	BitbucketBaseURLFlag       = "bitbucket-base-url"
 	BitbucketTokenFlag         = "bitbucket-token"
 	BitbucketUserFlag          = "bitbucket-user"
@@ -74,6 +75,10 @@ var stringFlags = []stringFlag{
 	{
 		name:        AtlantisURLFlag,
 		description: "URL that Atlantis can be reached at. Defaults to http://$(hostname):$port where $port is from --" + PortFlag + ".",
+	},
+	{
+		name:        AtlantisYAMLFilenameFlag,
+		description: "The name of the Atlantis config yaml file contained in each repo. Defaults to atlantis.yaml.",
 	},
 	{
 		name:        BitbucketUserFlag,

--- a/server/server.go
+++ b/server/server.go
@@ -84,6 +84,7 @@ type UserConfig struct {
 	AllowForkPRs           bool   `mapstructure:"allow-fork-prs"`
 	AllowRepoConfig        bool   `mapstructure:"allow-repo-config"`
 	AtlantisURL            string `mapstructure:"atlantis-url"`
+	AtlantisYAMLFilename   string `mapstructure:"atlantis-yaml-filename"`
 	BitbucketBaseURL       string `mapstructure:"bitbucket-base-url"`
 	BitbucketToken         string `mapstructure:"bitbucket-token"`
 	BitbucketUser          string `mapstructure:"bitbucket-user"`
@@ -275,6 +276,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 			WorkingDirLocker:    workingDirLocker,
 			AllowRepoConfig:     userConfig.AllowRepoConfig,
 			AllowRepoConfigFlag: config.AllowRepoConfigFlag,
+			AtlantisYAMLFilename: userConfig.AtlantisYAMLFilename,
 			PendingPlanFinder:   &events.PendingPlanFinder{},
 			CommentBuilder:      commentParser,
 		},


### PR DESCRIPTION
This allows repos to specify different atlantis configs that exist in the same repo, and supports running separate instances of atlantis for staging and production by pointing at different configs.